### PR TITLE
implement windows support on alfred cli

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,18 +1,14 @@
-name: ci
+name: ci-windows
 
 on: [push, pull_request]
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
-        env:
-            LD_LIBRARY_PATH: ""
-            pythonLocation: ""
-
+        runs-on: windows-latest
 
         strategy:
           matrix:
-            python-version: [3.8]
+            python-version: [3.8, 3.9, 3.10, 3.11]
 
         steps:
             - uses: actions/checkout@v2
@@ -25,12 +21,10 @@ jobs:
             - name: update package manager & install python3 environment
               run: |
                 pip install setuptools
-                pip install pipenv==2021.5.29
-                pipenv install --dev
+                pip install pipenv
+                pipenv install
 
             - name: continuous integration process
               shell: sh
               run: pipenv run -v alfred --debug ci
-              env:
-                  LD_LIBRARY_PATH: ""
-                  pythonLocation: ""
+

--- a/alfred/lib.py
+++ b/alfred/lib.py
@@ -44,15 +44,15 @@ def list_python_modules(folder_path: path) -> Iterator[path]:
 
 def list_hierarchy_directory(workingdir: path) -> List[path]:
     workingdir = os.path.realpath(workingdir)
-    all_parts = workingdir.split('/')
+    all_parts = workingdir.split(os.sep)
 
     result = [workingdir]
     while len(all_parts) != 1:
         all_parts.pop()
         if len(all_parts) == 1:
-            result.append('/')
+            result.append(os.sep)
         else:
-            result.append("/".join(all_parts))
+            result.append(os.sep.join(all_parts))
 
     return result
 

--- a/alfred/os.py
+++ b/alfred/os.py
@@ -1,0 +1,7 @@
+import os
+
+def is_posix():
+    return os.name == 'posix'
+
+def is_windows():
+    return os.name == 'nt'

--- a/alfred_cmd/ci.py
+++ b/alfred_cmd/ci.py
@@ -1,8 +1,14 @@
+import os
+
 import alfred
 
 
 @alfred.command('ci', help="execute continuous integration process of alfred")
 @alfred.option('-v', '--verbose', is_flag=True)
 def ci(verbose: bool):
-    alfred.invoke_command('lint', verbose=verbose)
+    if os.name == "posix":
+        alfred.invoke_command('lint', verbose=verbose)
+    else:
+        print("linter is not supported on non posix platform as windows")
+
     alfred.invoke_command('tests', verbose=verbose)

--- a/alfred_cmd/tests.py
+++ b/alfred_cmd/tests.py
@@ -17,8 +17,7 @@ def tests(verbose: bool):
 @alfred.option('-v', '--verbose', is_flag=True)
 def tests_units(verbose: bool):
     python = alfred.sh('python')
-    os.chdir(TESTS_PATH)
-    args = ['-m', 'unittest', 'discover', 'units']
+    args = ['-m', 'unittest', 'discover', 'tests/units']
 
     if verbose:
         args.append('-v')
@@ -31,8 +30,7 @@ def tests_units(verbose: bool):
 @alfred.option('-v', '--verbose', is_flag=True)
 def tests_acceptances(verbose: bool):
     python = alfred.sh('python')
-    os.chdir(TESTS_PATH)
-    args = ['-m', 'unittest', 'discover', 'acceptances']
+    args = ['-m', 'unittest', 'discover', 'tests/acceptances']
 
     if verbose:
         args.append('-v')

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,12 @@ setup(
     ],
     extras_require={
         'dev': [
-            'decorator',
             'pylint',
             'coverage',
             'twine'
+        ],
+        "dev_windows": [
+
         ]
     },
     license='MIT license',

--- a/tests/acceptances/test_cli.py
+++ b/tests/acceptances/test_cli.py
@@ -4,6 +4,7 @@ import unittest
 from click.testing import CliRunner
 
 from alfred.cli import cli
+from alfred.os import is_posix, is_windows
 from tests.fixtures import clone_fixture
 
 
@@ -15,10 +16,6 @@ class TestCli(unittest.TestCase):
         :return:
         """
         cli.reset()
-        self.currentCwd = os.getcwd()
-
-    def tearDown(self) -> None:
-        os.chdir(self.currentCwd)
 
     def test_cli_should_show_dedicated_help_to_the_user_when_the_directory_is_not_alfred(self):
         """
@@ -28,7 +25,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('empty_directory') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -46,7 +42,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('empty_directory') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -60,7 +55,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('project') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -74,7 +68,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('project') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -88,7 +81,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('empty_directory') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -102,7 +94,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('project') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -111,11 +102,10 @@ class TestCli(unittest.TestCase):
             # Assert
             self.assertEqual(0, result.exit_code)
 
-    def test_sh_should_not_work_with_wrong_multicommand(self):
+    def test_sh_should_not_work_with_wrong_multicommand_for_posix(self):
 
         with clone_fixture('project') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts
@@ -130,7 +120,6 @@ class TestCli(unittest.TestCase):
 
         with clone_fixture('wrong_command_module') as cwddir:
             # Assign
-            os.chdir(cwddir)
             runner = CliRunner()
 
             # Acts

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 
-from decorator import contextmanager
+from contextlib import contextmanager
 
 SCRIPT_DIRECTORY_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -18,7 +18,11 @@ def clone_fixture(fixture_name, working_dir=None):
                         os.path.isdir(os.path.join(SCRIPT_DIRECTORY_PATH, d))]
     raise Exception('the fixture {0} does not exists in fixtures : {1}'.format(fixture_name, fixtures_list))
 
+  previous_working_dir = os.getcwd()
   shutil.copytree(template_working_directory, working_directory)
-  yield working_directory
-
-  shutil.rmtree(working_directory)
+  try:
+    os.chdir(working_directory)
+    yield working_directory
+  finally:
+    os.chdir(previous_working_dir)
+    shutil.rmtree(working_directory)

--- a/tests/fixtures/project/alfred/cmd1.py
+++ b/tests/fixtures/project/alfred/cmd1.py
@@ -1,3 +1,5 @@
+import os
+
 import alfred
 
 
@@ -14,9 +16,9 @@ def hello_world_2_command(name):
 
 
 @alfred.command("multicommand")
-def multicommand():
-    echo = alfred.sh(["@@@@", "test"])
-    alfred.run(echo, ["1", "-eq", "1"])\
+def multicommand_posix():
+    echo = alfred.sh(["@@@@", "python"])
+    alfred.run(echo, ["--version"])
 
 
 @alfred.command("wrong_multicommand")

--- a/tests/units/test_lib.py
+++ b/tests/units/test_lib.py
@@ -1,12 +1,17 @@
+import os
 import unittest
 
 from alfred.lib import list_hierarchy_directory
+from alfred.os import is_posix, is_windows
 from alfred.type import path
 
 
 class TestLib(unittest.TestCase):
 
-    def test_list_hierarchy_directory_should_return_a_list_of_all_parents(self):
+    def test_list_hierarchy_directory_should_return_a_list_of_all_parents_for_linux(self):
+        if not is_posix():
+            self.skipTest("this test run only on linux or macos environment")
+
         # Assign
         mypath = path("/root/path/os/file")
         # Acts
@@ -17,6 +22,21 @@ class TestLib(unittest.TestCase):
         self.assertEqual("/root/path/os/file", parents_directory[0])
         self.assertEqual("/root/path/os", parents_directory[1])
         self.assertEqual("/", parents_directory[4])
+
+    def test_list_hierarchy_directory_should_return_a_list_of_all_parents_for_windows(self):
+        if not is_windows():
+            self.skipTest("this test run only on windows environment")
+
+        # Assign
+        mypath = path("C:\\root\\path\\os\\file")
+        # Acts
+        parents_directory = list_hierarchy_directory(mypath)
+
+        # Assert
+        self.assertEqual(5, len(parents_directory))
+        self.assertEqual("C:\\root\\path\\os\\file", parents_directory[0])
+        self.assertEqual("C:\\root\\path\\os", parents_directory[1])
+        self.assertEqual("\\", parents_directory[4])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add support for alfred-cli on windows

It becomes possible to execute with alfred commands written on windows, provided that the utilities that are invoked exist.

* feat: manage the separator for every platform
* feat: implement test validation working on windows
* feat: implement continuous integration process on windows