### PR TITLE
32 alfred autocompletion show instruction to configure alfred autocompletion in your profile

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -56,6 +56,9 @@ arguments of the command ``lint``.
 Advanced usage
 ==============
 
+.. contents::
+  :local:
+
 Show the version
 ----------------
 
@@ -63,6 +66,18 @@ Show the version
 
     alfred --version
 
+Configure autocompletion
+------------------------
+
+The ``alfred --completion`` command details the configuration to put in place to activate autocompletion in your shell.
+
+.. code-block:: bash
+
+    alfred --completion
+
+.. warning:: ``alfred --completion`` is available for bash, zsh and fish.
+
+    Configuring autocomplete relies on `click <https://click.palletsprojects.com/en/8.1.x/shell-completion/>`__. If you are using another shell and click supports it, open an issue with details for us to add support.
 
 Execute in debug mode
 ---------------------
@@ -89,8 +104,8 @@ with the command that is launched, the arguments that are passed to it and the e
         echo = alfred.sh("echo")
         alfred.run(echo, ["hello", "world"])
 
-Check command integrity
------------------------
+Check the alfred commands
+-------------------------
 
 ``alfred --check`` checks the integrity of the commands. It verifies that the command files are interpretable in the main project and in all subprojects.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -32,4 +32,6 @@ Projects
 Utilities
 *********
 
+* configure the shell completion with ``alfred --completion``
+* check the alfred commands for continuous integration with ``alfred --check``
 * show the installed alfred version with ``alfred --version``

--- a/poetry.lock
+++ b/poetry.lock
@@ -1239,6 +1239,18 @@ cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
+name = "shellingham"
+version = "1.5.3"
+description = "Tool to Detect Surrounding Shell"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.3-py2.py3-none-any.whl", hash = "sha256:419c6a164770c9c7cfcaeddfacb3d31ac7a8db0b0f3e9c1287679359734107e9"},
+    {file = "shellingham-1.5.3.tar.gz", hash = "sha256:cb4a6fec583535bc6da17b647dd2330cf7ef30239e05d547d99ae3705fd0f7f8"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1645,4 +1657,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e19097e3c98757f8d8cecfe85d008a2f5e2a53455e7992a168117976541a7b90"
+content-hash = "b4682d7e0f031fd11edc97a2264c72716aeb369bd2757ba0f2efda9171b6cb19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ python = "^3.8"
 click = "^8.1.0"
 plumbum = ">1.7.0,<1.9"
 toml = "^0.10"
+shellingham = "^1.3.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -101,6 +101,9 @@ class AlfredCli(click.MultiCommand):
         if ctx.params['version'] is True:
             self_command.version()
 
+        if ctx.params['completion'] is True:
+            self_command.completion()
+
         if ctx.params['check'] is True:
             self_command.check()
 
@@ -122,7 +125,8 @@ class AlfredCli(click.MultiCommand):
 @click.option("-d", "--debug", is_flag=True, help="display debug information like command runned and working directory")
 @click.option("-v", "--version", is_flag=True, help="display the version of alfred")
 @click.option("-c", "--check", is_flag=True, help="check the command integrity")
-def cli(debug: bool, version: bool, check):  # pylint: disable=unused-argument
+@click.option("--completion", is_flag=True, help="display instructions to enable completion for your shell")
+def cli(debug: bool, version: bool, check: bool, completion: bool):  # pylint: disable=unused-argument
     pass
 
 

--- a/src/alfred/main.py
+++ b/src/alfred/main.py
@@ -265,6 +265,8 @@ def invoke_itself(args) -> None:
             self_command.version()
         if '--check' in args or '-c' in args:
             self_command.check()
+        if '--completion' in args:
+            self_command.completion()
     except Exit as exception:
         if exception.exit_code == 0:
             return

--- a/src/alfred/resources/bash
+++ b/src/alfred/resources/bash
@@ -1,0 +1,8 @@
+Execute the following statement to activate completion.
+
+>>> eval "$(_ALFRED_COMPLETE=bash_source alfred)"
+
+alfred has detected you are using bash ({shell}).
+
+You have to add this statement to your profile to install completion permanently.
+The profile file for bash is ~/.bashrc

--- a/src/alfred/resources/fish
+++ b/src/alfred/resources/fish
@@ -1,0 +1,8 @@
+execute the following statement to activate completion.
+
+>>> eval "$(_ALFRED_COMPLETE=fish_source alfred | source)"
+
+alfred has detected you are using fish ({shell}).
+
+You have to add this statement to a completion file to install completion permanently.
+Configuring completion in fish should be done in ~/.config/fish/completions/alfred.fish

--- a/src/alfred/resources/zsh
+++ b/src/alfred/resources/zsh
@@ -1,0 +1,8 @@
+execute the following statement to activate completion.
+
+>>> eval "$(_ALFRED_COMPLETE=zsh_source alfred)"
+
+alfred has detected you are using zsh ({shell}).
+
+You have to add this statement to your profile to install completion permanently.
+The profile file for zsh is ~/.zshrc

--- a/src/alfred/self_command.py
+++ b/src/alfred/self_command.py
@@ -1,6 +1,12 @@
+import io
+import os
+from typing import List
+
+import shellingham
 from click.exceptions import Exit
 
 from alfred import logger, echo, commands
+from alfred.lib import ROOT_DIR
 
 
 def check():
@@ -18,3 +24,27 @@ def version():
     import alfred  # pylint: disable=import-outside-toplevel
     echo.message(f"{alfred.__version__}")
     raise Exit(code=0)
+
+
+def completion():
+    try:
+        shell = shellingham.detect_shell()
+        if shell[0] in completion_supported_shells():
+            path = os.path.join(ROOT_DIR, 'resources', shell[0])
+            if os.path.isfile(path) is True:
+                with io.open(path, "r", encoding='utf-8') as file:
+                    file_content = file.read()
+                    file_content = file_content.format(shell=shell[1])
+                    echo.message(file_content)
+                    raise Exit(code=0)
+            else:
+                echo.error(f"unable to find completion file for {shell[0]}")
+        else:
+            echo.error(f"unable to propose completion for {shell[0]}")
+            raise Exit(code=1)
+    except shellingham.ShellDetectionFailure as exception:
+        echo.error("unable to detect your shell to propose completion instructions")
+        raise Exit(code=1) from exception
+
+def completion_supported_shells() -> List[str]:
+    return ["bash", "zsh", "fish"]

--- a/tests/units/test_self_command.py
+++ b/tests/units/test_self_command.py
@@ -1,0 +1,13 @@
+import os.path
+
+from alfred import self_command
+from alfred.lib import ROOT_DIR
+
+
+def test_shell_completion_files_should_be_present():
+    # Arrange
+    # Acts
+    shells = self_command.completion_supported_shells()
+    for shell_name in shells:
+        path = os.path.join(ROOT_DIR, 'resources', shell_name)
+        assert os.path.isfile(path), f"completion file for {shell_name} should be present at {path}"


### PR DESCRIPTION
implement the #32 

The ``alfred --completion`` command shows the user the shell statement to execute to enable autocomplete.

The shell supported are the one from click documentation :
* bash
* zsh
* fish

The command displays after instructions to permanently configure autocompletion.

```textplain
execute the following statement to activate autocompletion for alfred on bash (shell we have detected)

>>> eval "$(_ALFRED_COMPLETE=bash_source alfred)"

Adding this statement to your shell profile installs alfred's autocompletion permanently. 
You will avoid running this command every time you open a terminal window.

The profile file for bash is ~/.bashrc
```