### PR TITLE
detect automatically virtual environment in ``.venv`` directory

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -436,7 +436,8 @@ disable=raw-checker-failed,
         logging-fstring-interpolation,
         too-few-public-methods,
         no-else-raise,
-        cyclic-import
+        cyclic-import,
+        no-else-return
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -28,6 +28,7 @@ Projects
 * discovers commands in multiple locations
 * discover commands in subprojects as multi command ``alfred {project} {command}``
 * execute a command from a virtual environment associated with the project
+* detect automatically virtual environment in ``.venv`` directory
 
 Utilities
 *********

--- a/docs/source/project.rst
+++ b/docs/source/project.rst
@@ -50,6 +50,7 @@ Project manifest
     python_path_project_root = true # optional
     python_path_extends = [] # optional
     venv = "src/.." # optional
+    venv_dotvenv_ignore = false # optional
 
 Section [alfred]
 ================
@@ -147,7 +148,7 @@ Section [alfred.project]
 
         The virtual environment that is used to run the commands for this project. If this parameter is absent, the interpreter used to invoke the parent is used.
 
-        .. code-block::
+        .. code-block:: toml
 
             [alfred.project]
             venv = ".venv"
@@ -156,6 +157,15 @@ Section [alfred.project]
 
             For expressions that are relative paths, they are resolved from the folder that contains
             the corresponding .alfred.toml manifest.
+
+    venv_dotvenv_ignore (optional)
+
+        ignore the ``./.venv`` folder when searching for a virtual environment.
+
+        .. code-block:: toml
+
+            [alfred.project]
+            venv_dotvenv_ignore = true
 
 Subproject : Organization of a mono-repository
 **********************************************

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -163,13 +163,13 @@ def _context_middleware() -> Generator[None, None, None]:
     pathsep = os.pathsep
 
     pythonpath = pathsep.join(sys.path)
-    if manifest.pythonpath_project_root():
+    if manifest.lookup_parameter_project('pythonpath_project_root'):
         _pythonpath = pythonpath.split(pathsep)
         root_directory = project_directory()
         _pythonpath.append(root_directory)
         pythonpath = pathsep.join(_pythonpath)
 
-    extensions = manifest.pythonpath_extends()
+    extensions = manifest.lookup_parameter_project('pythonpath_extends')
     if len(extensions) > 0:
         _pythonpath = pythonpath.split(pathsep)
         root_directory = project_directory()

--- a/src/alfred/commands.py
+++ b/src/alfred/commands.py
@@ -73,7 +73,7 @@ def list_all(project_dir: t.Optional[str] = None, show_error: bool = True) -> Li
         subproject = manifest.name(project_dir)
 
     commands = []
-    for pattern in manifest.project_commands(project_dir):
+    for pattern in manifest.lookup_parameter_project('command', project_dir):
         commands = _load_commands(commands, pattern, project_dir, subproject, show_error)
 
     subprojects_glob = manifest.subprojects(project_dir)
@@ -170,7 +170,7 @@ def check_integrity(project_dir: t.Optional[str] = None) -> bool:
 
     all_projects = project.list_all(project_dir)
     for _project in all_projects:
-        for pattern in manifest.project_commands(_project.directory):
+        for pattern in manifest.lookup_parameter_project('command', _project.directory):
             try:
                 logger.debug(f"Checking commands integrity of project '{_project.name}'")
                 commands = _load_commands(commands, pattern, _project.directory, None, True, raise_error=True)

--- a/src/alfred/ctx.py
+++ b/src/alfred/ctx.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from click.exceptions import Exit
 
-from alfred import manifest, interpreter
+from alfred import interpreter
 from alfred.decorator import AlfredCommand
 from alfred.exceptions import NotInCommand
 from alfred.logger import get_logger
@@ -51,7 +51,7 @@ def invoke_through_external_venv(args: List[str]) -> None:
 
     """
     alfred_cmd = current_command()
-    venv = manifest.lookup_venv(alfred_cmd.project_dir)
+    venv = interpreter.venv_lookup(alfred_cmd.project_dir)
     exit_code, _, _ = interpreter.run_module(module='alfred.cli', venv=venv, args=args)
 
     if exit_code != 0:
@@ -75,11 +75,11 @@ def should_use_external_venv() -> bool:
     """
     alfred_cmd = current_command()
     if alfred_cmd is not None:
-        venv = manifest.lookup_venv(alfred_cmd.project_dir)
+        venv = interpreter.venv_lookup(alfred_cmd.project_dir)
 
-        if venv is not None and interpreter.get_venv() != venv:
+        if venv is not None and interpreter.venv_get() != venv:
             _logger = get_logger()
-            _logger.debug(f"alfred interpreter - current venv: {interpreter.get_venv()}")
+            _logger.debug(f"alfred interpreter - current venv: {interpreter.venv_get()}")
             _logger.debug(f"alfred interpreter - expected venv: {venv}")
             return True
 

--- a/src/alfred/domain/manifest.py
+++ b/src/alfred/domain/manifest.py
@@ -1,6 +1,8 @@
+import dataclasses
 import logging
 import os.path
-from typing import List
+from typing import List, Optional, Any, Callable
+
 
 class Environment:  # pylint: disable=too-few-public-methods
 
@@ -8,6 +10,13 @@ class Environment:  # pylint: disable=too-few-public-methods
         self.key = key
         self.value = value
 
+@dataclasses.dataclass
+class ManifestParameter:
+    parameter: str
+    section: Optional[str] = None
+    default: Optional[Any] = None
+    formatter: Callable[[str, Any], Any] = lambda projectdir, value: value
+    legacy_aliases: List[str] = dataclasses.field(default_factory=list)
 
 class AlfredManifest:
 

--- a/tests/integrations/test_interpreter.py
+++ b/tests/integrations/test_interpreter.py
@@ -1,0 +1,49 @@
+import io
+
+import fixtup
+import toml
+
+from alfred import interpreter
+
+
+def test_venv_lookup_should_detect_venv_automatically():
+    # Arrange
+    with fixtup.up('project_with_venv'):
+        # remove venv parameter from manifest
+        with io.open('.alfred.toml', 'r') as filep:
+            manifest = toml.load(filep)
+            del manifest['alfred']['project']['venv']
+        with io.open('.alfred.toml', 'w') as filep:
+            toml.dump(manifest, filep)
+
+        # Acts
+        result = interpreter.venv_lookup()
+        # Acts
+        assert result.endswith('.venv')
+
+
+def test_venv_lookup_should_detect_ignore_dotvenv_when_venv_dotvenv_ignore_is_at_true():
+    # Arrange
+    with fixtup.up('project_with_venv'):
+        # remove venv parameter from manifest and add ignore dotvenv discovery
+        with io.open('.alfred.toml', 'r') as filep:
+            manifest = toml.load(filep)
+            del manifest['alfred']['project']['venv']
+            manifest['alfred']['project']['venv_dotvenv_ignore'] = True
+        with io.open('.alfred.toml', 'w') as filep:
+            toml.dump(manifest, filep)
+
+        # Acts
+        result = interpreter.venv_lookup()
+
+        # Acts
+        assert result is None
+
+
+def test_venv_lookup_should_not_detect_venv_when_is_absent():
+    # Arrange
+    with fixtup.up('project'):
+        # Acts
+        result = interpreter.venv_lookup()
+        # Acts
+        assert result is None

--- a/tests/integrations/test_manifest.py
+++ b/tests/integrations/test_manifest.py
@@ -7,7 +7,7 @@ from alfred import manifest
 
 def test_lookup_venv_should_return_none_when_no_venv():
     with fixtup.up('project'):
-        assert manifest.lookup_venv() is None
+        assert manifest.lookup_parameter_project('venv') is None
 
 
 def test_lookup_venv_should_return_venv_when_it_is_defined():
@@ -15,14 +15,14 @@ def test_lookup_venv_should_return_venv_when_it_is_defined():
         root_path = os.getcwd()
 
         expected_venv_path = os.path.realpath(os.path.join(root_path, 'products', 'product1', '.venv'))
-        assert manifest.lookup_venv(os.path.join(root_path, 'products', 'product1')) == expected_venv_path
+        assert manifest.lookup_parameter_project(project_dir=os.path.join(root_path, 'products', 'product1'), parameter='venv') == expected_venv_path
 
 
 def test_lookup_venv_should_return_none_when_venv_is_undefined():
     with fixtup.up('multiproject'):
         root_path = os.getcwd()
 
-        assert manifest.lookup_venv(os.path.join(root_path, 'products', 'product2')) is None
+        assert manifest.lookup_parameter_project(project_dir=os.path.join(root_path, 'products', 'product2'), parameter='venv') is None
 
 
 def test_name_should_return_parent_directory_name_when_name_parameter_is_missing_in_manifest():
@@ -47,13 +47,13 @@ def test_prefix_should_return_specified_prefix():
 
 def test_project_commands_pattern_should_return_default_value():
     with fixtup.up('project'):
-        assert manifest.project_commands() == ["alfred/*.py"]
+        assert manifest.lookup_parameter_project('command') == ["alfred/*.py"]
 
 
 def test_project_commands_pattern_should_return_specified_values():
     with fixtup.up('project_with_command'):
-        assert manifest.project_commands() == ["customdir/*.py"]
+        assert manifest.lookup_parameter_project('command') == ["customdir/*.py"]
 
 def test_python_path_extends_should_return_a_list_of_directory():
     with fixtup.up('pythonpath_extends'):
-        assert manifest.pythonpath_extends() == ["tests"]
+        assert manifest.lookup_parameter_project('pythonpath_extends') == ["tests"]


### PR DESCRIPTION
* feat: detect virtual environment in .venv directory automatically

implement #19

---

alfred detects the presence of a virtual environment .venv at the root of a project. It uses the python of this virtual environment without prior configuration.

If an environment is specified in the manifest and a .venv virtual environment is also detected, the python of the virtual environment specified in the manifest is used. If the specified virtual environment is invalid, an exception is thrown.

A venv_dotvenv_ignore parameter in the alfred.toml manifest allows to disable the automatic detection of the virtual environment at the root. By default, this parameter is false.