### PR TITLE
52 the working directory in a command is always the root of the project

### DIFF
--- a/docs/source/toolkit.rst
+++ b/docs/source/toolkit.rst
@@ -39,3 +39,5 @@ API to check environment
 .. autofunction:: is_macos
 
 .. autofunction:: project_directory
+
+.. autofunction:: execution_directory

--- a/src/alfred/__init__.py
+++ b/src/alfred/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from alfred.decorator import command, option
-from alfred.main import invoke_command, run, sh, env, project_directory, pythonpath, invoke_itself, CMD_RUNNING
+from alfred.main import invoke_command, run, sh, env, project_directory, pythonpath, invoke_itself, CMD_RUNNING, execution_directory
 from alfred.os import is_posix, is_windows, is_linux, is_macos
 
 """

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -132,6 +132,7 @@ class AlfredCli(click.MultiCommand):
 @click.option("--completion", is_flag=True, help="display instructions to enable completion for your shell")
 def cli(debug: bool, version: bool, check: bool, completion: bool):  # pylint: disable=unused-argument
     alfred_ctx.flag_set('--debug', debug)
+    alfred_ctx.directory_execution_set(os.getcwd())
 
 
 def display_obsolete_manifests():

--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -123,6 +123,11 @@ class AlfredCli(click.MultiCommand):
         """
         super().invoke(ctx)
 
+    def parse_args(self, ctx: Context, args: List[str]) -> List[str]:
+        if alfred_ctx.cli_args() is None:
+            alfred_ctx.cli_args_set(args)
+        return super().parse_args(ctx, args)
+
 
 @click.command(cls=AlfredCli,
                help='alfred is a building tool to make engineering tasks easier to develop and to maintain')
@@ -130,7 +135,8 @@ class AlfredCli(click.MultiCommand):
 @click.option("-v", "--version", is_flag=True, help="display the version of alfred")
 @click.option("-c", "--check", is_flag=True, help="check the command integrity")
 @click.option("--completion", is_flag=True, help="display instructions to enable completion for your shell")
-def cli(debug: bool, version: bool, check: bool, completion: bool):  # pylint: disable=unused-argument
+@click.pass_context
+def cli(ctx, debug: bool, version: bool, check: bool, completion: bool):  # pylint: disable=unused-argument
     alfred_ctx.flag_set('--debug', debug)
     alfred_ctx.directory_execution_set(os.getcwd())
 

--- a/src/alfred/ctx.py
+++ b/src/alfred/ctx.py
@@ -24,6 +24,7 @@ class Context:
     commands_stack: List[AlfredCommand] = dataclasses.field(default_factory=list)
     mode: str = Mode.Unknown
     flags: List[str] = dataclasses.field(default_factory=list)
+    directory_execution: str = ""
 
     @property
     def running(self) -> bool:
@@ -55,6 +56,13 @@ def current_command() -> Optional[AlfredCommand]:
 def command_run() -> bool:
     return _context.mode == Mode.RunCommand
 
+
+def directory_execution_set(directory: str) -> None:
+    _context.directory_execution = directory
+
+
+def directory_execution() -> Optional[str]:
+    return _context.directory_execution
 
 def flag_set(flag: str, enable: bool) -> None:
     """

--- a/src/alfred/ctx.py
+++ b/src/alfred/ctx.py
@@ -3,6 +3,7 @@ This module exposes functions that manage the execution context of a command,
 such as the current command, its parents, ...
 """
 import contextlib
+import copy
 import dataclasses
 from typing import List, Optional
 
@@ -13,24 +14,35 @@ from alfred import interpreter, logger, echo
 from alfred.decorator import AlfredCommand
 from alfred.exceptions import NotInCommand
 
-
 class Mode:
     ListCommands = "list_commands"
     RunCommand = "run_command"
     Unknown = "unknown"
 
 @dataclasses.dataclass
+class InvocationContext:
+    """
+    The invocation context represents Alfred's summon information.
+
+    Once written, its attributes, once written, remain constant. If alfred is invoked in a subproject, 7
+    the invocation context is loaded from a file written with the parent's pid.
+
+    Attributes must be primitive types to be serializable.
+    """
+    directory_execution: Optional[str] = None
+    args: Optional[List[str]] = None
+    mode: str = Mode.Unknown
+    flag: List[str] = dataclasses.field(default_factory=list)
+
+@dataclasses.dataclass
 class Context:
     commands_stack: List[AlfredCommand] = dataclasses.field(default_factory=list)
-    mode: str = Mode.Unknown
-    flags: List[str] = dataclasses.field(default_factory=list)
-    directory_execution: str = ""
 
     @property
     def running(self) -> bool:
         return len(self.commands_stack) > 0
 
-
+_invocation_context = InvocationContext()
 _context = Context()
 
 def assert_in_command(instruction: str) -> None:
@@ -54,35 +66,45 @@ def current_command() -> Optional[AlfredCommand]:
 
 
 def command_run() -> bool:
-    return _context.mode == Mode.RunCommand
+    return _invocation_context.mode == Mode.RunCommand
 
+def cli_args_set(args: List[str]) -> None:
+    _invocation_context.args = copy.copy(args)
+
+
+def cli_args() -> Optional[List[str]]:
+    return _invocation_context.args
 
 def directory_execution_set(directory: str) -> None:
-    _context.directory_execution = directory
+    _invocation_context.directory_execution = directory
 
 
 def directory_execution() -> Optional[str]:
-    return _context.directory_execution
+    return _invocation_context.directory_execution
 
 def flag_set(flag: str, enable: bool) -> None:
     """
     configure flag to forward to interpreter when invoking a command
     """
-    if enable and flag not in _context.flags:
-        _context.flags.append(flag)
+    if enable and flag not in _invocation_context.flag:
+        _invocation_context.flag.append(flag)
 
+def invocation_options() -> List[str]:
+    """
+    recomposes the list of invocation options (flags + options).
 
-def flags() -> List[str]:
-    return _context.flags
+    Options management is missing because Alfred is not using it at the moment.
+    """
+    return _invocation_context.flag
 
 
 def mode_unknown() -> str:
-    return _context.mode == Mode.Unknown
+    return _invocation_context.mode == Mode.Unknown
 
 
 def mode_set(mode: str) -> None:
-    logger.debug(f"mode set '{mode}' - previous '{_context.mode}'")
-    _context.mode = mode
+    logger.debug(f"mode set '{mode}'")
+    _invocation_context.mode = mode
 
 
 def invoke_through_external_venv(args: List[str]) -> None:
@@ -141,8 +163,7 @@ def stack_root_command(command: AlfredCommand) -> None:
 @contextlib.contextmanager
 def stack_subcommand(command: AlfredCommand) -> None:
     """
-    Ajoute une nouvelle commande sur la pile des commandes en cours.
-    Une fois l'exécution
+    Adds a new command to the current command stack.
 
     >>> with ctx.stack_subcommand(command):
     >>>     pass
@@ -161,8 +182,13 @@ def use_new_context() -> None:
     >>> with ctx.use_new_context():
     >>>     pass
     """
-    global _context # pylint: disable=global-statement
+    global _context, _invocation_context # pylint: disable=global-statement
     previous_context = _context
-    _context = Context()
-    yield
-    _context = previous_context
+    previous_invocation_context = _invocation_context
+    try:
+        _context = Context()
+        _invocation_context = InvocationContext()
+        yield
+    finally:
+        _context = previous_context
+        _invocation_context = previous_invocation_context

--- a/src/alfred/decorator.py
+++ b/src/alfred/decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import click
 
 
-from alfred.domain.command import AlfredCommand, make_context
+from alfred.domain.command import AlfredCommand, alfred_wrapper
 
 
 def command(name: str, help: str = '', **attrs: Any):  # pylint: disable=redefined-builtin
@@ -30,7 +30,7 @@ def command(name: str, help: str = '', **attrs: Any):  # pylint: disable=redefin
 
     def alfred_decorated(func):
         alfred_command = AlfredCommand()
-        func = make_context(alfred_command, func)
+        func = alfred_wrapper(alfred_command, func)
 
         click_decorator = click.command(name, help=help, **attrs)
         click_command = click_decorator(func)

--- a/src/alfred/domain/command.py
+++ b/src/alfred/domain/command.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import os
 from typing import Optional, Callable, Generator
 
 from click import BaseCommand
@@ -63,7 +64,7 @@ class AlfredCommand:
     @contextlib.contextmanager
     def mount_context(self):
         """
-        Monte le context avant d'exécuter la commande click.
+        Mount the context before executing the click command.
 
         :return:
         """
@@ -74,11 +75,22 @@ class AlfredCommand:
             yield
 
 
-def make_context(alfred_command: AlfredCommand, func: Callable) -> Callable:
+def alfred_wrapper(alfred_command: AlfredCommand, func: Callable) -> Callable:
+    """
+    configure the context before executing the click command.
+
+    * configure the working folder
+    * configure the pythonpath
+    """
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         with alfred_command.mount_context():
-            return func(*args, **kwargs)
+            previous_directory = os.getcwd()
+            try:
+                os.chdir(alfred_command.project_dir)
+                return func(*args, **kwargs)
+            finally:
+                os.chdir(previous_directory)
 
     return wrapper

--- a/src/alfred/interpreter.py
+++ b/src/alfred/interpreter.py
@@ -2,6 +2,7 @@ import os
 import sys
 from typing import Optional, List, Tuple, Union
 
+import click
 import plumbum
 from plumbum import local
 from plumbum.commands.modifiers import _TEE
@@ -57,8 +58,8 @@ def run_module(module: str, venv: str, args: List[str]) -> Tuple[int, str, str]:
             #
             # I don't know how to do better.
             exit_code, stdout, stderr = python[python_args].run(retcode=None)
-            print(stdout)
-            print(stderr)
+            click.echo(stdout)
+            click.echo(stderr, err=True)
         else:
             exit_code, stdout, stderr = python[python_args] & _TEE(retcode=None)
         return exit_code, stdout, stderr

--- a/src/alfred/interpreter.py
+++ b/src/alfred/interpreter.py
@@ -46,7 +46,7 @@ def run_module(module: str, venv: str, args: List[str]) -> Tuple[int, str, str]:
         raise AlfredException(f"bin folder not found in venv: {venv}, bin_path={bin_path}")
 
     python = plumbum.local[python_path]
-    args = ctx.flags() + args
+    args = ctx.invocation_options() + args
     logger.debug(f"alfred interpreter - switch to python: {python_path} : args={args}")
 
     with local.env(VIRTUAL_ENV=venv, PATH=global_path):

--- a/src/alfred/main.py
+++ b/src/alfred/main.py
@@ -84,8 +84,10 @@ def execution_directory() -> str:
     """
     Returns the directory from which the command is executed.
 
-    The working folder is overloaded by alfred to be the project directory of the current command.
+    The working folder return by ``os.getcwd`` is set to the project directory inside a command.
     This allows to change the path in commands knowing where the working directory is.
+
+    The project directory is the first parent where the `.alfred.toml` file is present.
 
     >>> @alfred.command("execution_directory")
     >>> def execution_directory_command():

--- a/tests/acceptances/test_cli.py
+++ b/tests/acceptances/test_cli.py
@@ -329,5 +329,29 @@ def test_alfred_invoke_command_forward_debug_flag_to_command(caplog):
         execute_child_interpreter = [record.message for record in caplog.records if ' switch to python' in record.message]
         assert '--debug' in execute_child_interpreter[0]
 
+
+def test_alfred_working_directory_is_the_root_of_the_project(caplog):
+    with fixtup.up('project'), caplog.at_level(logging.DEBUG):
+        root_directory = os.getcwd()
+
+        os.makedirs('src', exist_ok=True)
+        os.chdir('src')
+        exit_code, stdout, _ = alfred_fixture.invoke(["cmd:print_cwd"])
+
+        assert exit_code == 0
+        assert stdout.strip() == root_directory
+
+
+def test_alfred_working_directory_is_the_root_of_the_subproject():
+    with fixtup.up('multiproject'):
+        directory_to_create = os.path.join('products', 'product1', 'src')
+        os.makedirs(directory_to_create, exist_ok=True)
+
+        root_directory = os.getcwd()
+        exit_code, stdout, stderr = alfred_fixture.invoke(["product1", "print_cwd"])
+
+        assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
+        assert stdout.strip() == os.path.join(root_directory, 'products', 'product1')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/acceptances/test_cli.py
+++ b/tests/acceptances/test_cli.py
@@ -256,7 +256,7 @@ class TestCli(unittest.TestCase):
 
             # Assert
             assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
-            assert stderr == ''
+            assert stderr.strip() == ''
             assert "hello" in stdout
 
     def test_alfred_check_should_exit_with_one_when_alfred_command_are_corrupted(self):
@@ -339,7 +339,7 @@ def test_alfred_working_directory_is_the_root_of_the_project():
         exit_code, stdout, _ = alfred_fixture.invoke(["cmd:print_cwd"])
 
         assert exit_code == 0
-        assert stdout.strip() == root_directory
+        assert os.path.realpath(stdout.strip()) == os.path.realpath(root_directory)
 
 
 def test_alfred_execution_directory_return_the_directory_where_invocation_is_done():
@@ -351,7 +351,7 @@ def test_alfred_execution_directory_return_the_directory_where_invocation_is_don
         exit_code, stdout, _ = alfred_fixture.invoke(["cmd:execution_directory"])
 
         assert exit_code == 0
-        assert stdout.strip() == os.path.join(root_directory, 'src')
+        assert os.path.realpath(stdout.strip()) == os.path.realpath(os.path.join(root_directory, 'src'))
 
 
 def test_alfred_working_directory_is_the_root_of_the_subproject():
@@ -363,7 +363,7 @@ def test_alfred_working_directory_is_the_root_of_the_subproject():
         exit_code, stdout, stderr = alfred_fixture.invoke(["product1", "print_cwd"])
 
         assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
-        assert stdout.strip() == os.path.join(root_directory, 'products', 'product1')
+        assert os.path.realpath(stdout.strip()) == os.path.realpath(os.path.join(root_directory, 'products', 'product1')), f"stdout={stdout}"
 
 
 def test_alfred_execution_directory_should_return_directory_where_command_has_been_invocked_on_subproject():
@@ -375,7 +375,7 @@ def test_alfred_execution_directory_should_return_directory_where_command_has_be
         exit_code, stdout, stderr = alfred_fixture.invoke(["product1", "execution_directory"])
 
         assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
-        assert stdout.strip() == os.path.join(root_directory)
+        assert os.path.realpath(stdout.strip()) == os.path.realpath(root_directory), f"stdout={stdout}"
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/acceptances/test_cli.py
+++ b/tests/acceptances/test_cli.py
@@ -330,8 +330,8 @@ def test_alfred_invoke_command_forward_debug_flag_to_command(caplog):
         assert '--debug' in execute_child_interpreter[0]
 
 
-def test_alfred_working_directory_is_the_root_of_the_project(caplog):
-    with fixtup.up('project'), caplog.at_level(logging.DEBUG):
+def test_alfred_working_directory_is_the_root_of_the_project():
+    with fixtup.up('project'):
         root_directory = os.getcwd()
 
         os.makedirs('src', exist_ok=True)
@@ -340,6 +340,18 @@ def test_alfred_working_directory_is_the_root_of_the_project(caplog):
 
         assert exit_code == 0
         assert stdout.strip() == root_directory
+
+
+def test_alfred_execution_directory_return_the_directory_where_invocation_is_done():
+    with fixtup.up('project'):
+        root_directory = os.getcwd()
+
+        os.makedirs('src', exist_ok=True)
+        os.chdir('src')
+        exit_code, stdout, _ = alfred_fixture.invoke(["cmd:execution_directory"])
+
+        assert exit_code == 0
+        assert stdout.strip() == os.path.join(root_directory, 'src')
 
 
 def test_alfred_working_directory_is_the_root_of_the_subproject():
@@ -352,6 +364,18 @@ def test_alfred_working_directory_is_the_root_of_the_subproject():
 
         assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
         assert stdout.strip() == os.path.join(root_directory, 'products', 'product1')
+
+
+def test_alfred_execution_directory_should_return_directory_where_command_has_been_invocked_on_subproject():
+    with fixtup.up('multiproject'):
+        directory_to_create = os.path.join('products', 'product1', 'src')
+        os.makedirs(directory_to_create, exist_ok=True)
+
+        root_directory = os.getcwd()
+        exit_code, stdout, stderr = alfred_fixture.invoke(["product1", "execution_directory"])
+
+        assert exit_code == 0, f"stdout={stdout}\nstderr={stderr}"
+        assert stdout.strip() == os.path.join(root_directory)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/fixtures/multiproject/products/product1/alfred/cmd.py
+++ b/tests/fixtures/multiproject/products/product1/alfred/cmd.py
@@ -12,3 +12,8 @@ def print_python_exec():
 @alfred.command("print_cwd")
 def print_cwd():
     print(os.getcwd())
+
+
+@alfred.command("execution_directory")
+def execution_directory():
+    print(alfred.execution_directory())

--- a/tests/fixtures/multiproject/products/product1/alfred/cmd.py
+++ b/tests/fixtures/multiproject/products/product1/alfred/cmd.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import alfred
@@ -6,3 +7,8 @@ import alfred
 @alfred.command("print_python_exec")
 def print_python_exec():
     print(sys.executable)
+
+
+@alfred.command("print_cwd")
+def print_cwd():
+    print(os.getcwd())

--- a/tests/fixtures/project/alfred/cmd1.py
+++ b/tests/fixtures/project/alfred/cmd1.py
@@ -39,6 +39,11 @@ def print_python_exec():
     print(sys.executable)
 
 
+@alfred.command("print_cwd")
+def print_cwd():
+    print(os.getcwd())
+
+
 @alfred.command("multicommand")
 def multicommand_posix():
     echo = alfred.sh(["@@@@", "python"])

--- a/tests/fixtures/project/alfred/cmd1.py
+++ b/tests/fixtures/project/alfred/cmd1.py
@@ -44,6 +44,11 @@ def print_cwd():
     print(os.getcwd())
 
 
+@alfred.command("execution_directory")
+def execution_directory():
+    print(alfred.execution_directory())
+
+
 @alfred.command("multicommand")
 def multicommand_posix():
     echo = alfred.sh(["@@@@", "python"])


### PR DESCRIPTION
fix #52 

---
The working folder when an alfred command is launched is always the root of the project where the ``.alfred.toml`` manifest is located. The developer can change the folder without composing path from the ``alfred.project_directory`` function.

For example, if he wants the command to run in the frontend folder, he just uses ``os.chwd('frontend')``.

* implement the function ``alfred.execution_directory`` returns the folder in which a user invoked the alfred command.
* document the function ``alfred.execution_directory`` in ``Command toolkit``