### PR TITLE
detect automatically virtual environment from poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+            python-version: ["3.8", "3.9", "3.10", "3.11"]
 
         steps:
             - uses: actions/checkout@v2

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -29,6 +29,7 @@ Projects
 * discover commands in subprojects as multi command ``alfred {project} {command}``
 * execute a command from a virtual environment associated with the project
 * detect automatically virtual environment in ``.venv`` directory
+* detect automatically virtual environment mount with ``poetry``
 * add pythonpath, path into the manifest to use external program or script more easily
 
 Utilities

--- a/docs/source/project.rst
+++ b/docs/source/project.rst
@@ -52,6 +52,7 @@ Project manifest
     python_path_extends = [ ] # optional
     venv = null # optional
     venv_dotvenv_ignore = false # optional
+    venv_poetry_ignore = false # optional
 
 Section [alfred]
 ================
@@ -188,10 +189,20 @@ Section [alfred.project]
             [alfred.project]
             venv_dotvenv_ignore = true
 
+
+    venv_poetry_ignore (optional)
+
+        ignores poetry's virtual environment when searching for a virtual environment.
+
+        .. code-block:: toml
+
+            [alfred.project]
+            venv_poetry_ignore = true
+
 Subproject : Organization of a mono-repository
 **********************************************
 
-In version-control systems, a monorepo ("mono" meaning 'single' and "repo" being short for 'repository') is a software-development strategy in which the code for a number of projects is stored in the same repository
+In version-control systems, a monorepo is a software-development strategy in which the code for a number of projects is stored in the same repository
 
 In the case where these are different applications, they can have their own manifest, therefore their own venv.
 Alfred allows them to be managed in a unified way thanks to the concept of sub-projects.

--- a/src/alfred/logger.py
+++ b/src/alfred/logger.py
@@ -14,3 +14,13 @@ def debug(message: str):
     >>> logger.debug("hello world")
     """
     logger.debug(message, stacklevel=2)
+
+
+def warning(message: str):
+    """
+    log a warning message
+
+    >>> from alfred import logger
+    >>> logger.warning("hello world")
+    """
+    logger.warning(message, stacklevel=2)

--- a/src/alfred/manifest.py
+++ b/src/alfred/manifest.py
@@ -22,6 +22,7 @@ def manifest_definitions():
         ManifestParameter('path_extends', section='alfred.project', default=[], formatter=_format_path_list, checker=_check_path_list),
         ManifestParameter('venv', section='alfred.project', default=None, formatter=_format_path),
         ManifestParameter('venv_dotvenv_ignore', section='alfred.project', default=False),
+        ManifestParameter('venv_poetry_ignore', section='alfred.project', default=False),
     ]
 
 

--- a/src/alfred/venv_plugins/__init__.py
+++ b/src/alfred/venv_plugins/__init__.py
@@ -1,0 +1,7 @@
+from alfred.venv_plugins import dotvenv as dotvenv_plugin
+from alfred.venv_plugins import venv as venv_plugin
+from alfred.venv_plugins import poetry as poetry_plugin
+
+dotvenv = dotvenv_plugin
+venv = venv_plugin
+poetry = poetry_plugin

--- a/src/alfred/venv_plugins/base.py
+++ b/src/alfred/venv_plugins/base.py
@@ -1,0 +1,15 @@
+import os.path
+
+import alfred.os
+
+def venv_is_valid(venv: str) -> bool:
+    """
+    checks if a folder is a valid virtualenv
+
+    * checks for the presence of the `bin` folder for posix systems
+    * checks for the presence of the `Scripts` folder for windows
+    """
+    if alfred.os.is_windows():
+        return os.path.isdir(os.path.join(venv, 'Scripts'))
+    else:
+        return os.path.isdir(os.path.join(venv, 'bin'))

--- a/src/alfred/venv_plugins/dotvenv.py
+++ b/src/alfred/venv_plugins/dotvenv.py
@@ -1,0 +1,24 @@
+"""
+Detect when the project contains a virtual environment mount in .venv. He retrieve the virtual environment.
+
+If the parameter venv_dotvenv_ignore is set in the section project, then the code move on to the next plugin.
+"""
+import os.path
+from typing import Optional
+
+from alfred import manifest, logger
+from alfred.venv_plugins.base import venv_is_valid
+
+
+def venv_lookup(project_dir: str) -> Optional[str]:
+    venv_dotvenv_ignore = manifest.lookup_parameter_project('venv_dotvenv_ignore', project_dir)
+    if venv_dotvenv_ignore is True:
+        return None
+
+    dotvenv_path = os.path.join(project_dir, '.venv')
+    if os.path.isdir(dotvenv_path) and venv_is_valid(dotvenv_path):
+        return dotvenv_path
+    elif os.path.isdir(dotvenv_path):
+        logger.debug(f"venv {dotvenv_path} is not valid")
+
+    return None

--- a/src/alfred/venv_plugins/dotvenv.py
+++ b/src/alfred/venv_plugins/dotvenv.py
@@ -16,9 +16,12 @@ def venv_lookup(project_dir: str) -> Optional[str]:
         return None
 
     dotvenv_path = os.path.join(project_dir, '.venv')
-    if os.path.isdir(dotvenv_path) and venv_is_valid(dotvenv_path):
-        return dotvenv_path
-    elif os.path.isdir(dotvenv_path):
-        logger.debug(f"venv {dotvenv_path} is not valid")
+    if not os.path.isdir(dotvenv_path):
+        logger.debug(f"{project_dir} does not contains .venv directory")
+        return None
 
+    if venv_is_valid(dotvenv_path):
+        return dotvenv_path
+
+    logger.warning(f"virtual env in {dotvenv_path} is not valid. You should install / reinstall it")
     return None

--- a/src/alfred/venv_plugins/poetry.py
+++ b/src/alfred/venv_plugins/poetry.py
@@ -3,7 +3,70 @@ Detect when a project use poetry. He retrieve the virtual environment it created
 
 If the parameter venv_poetry_ignore is set in the section project, then the code move on to the next plugin.
 """
+import io
+import os
+import shutil
+import subprocess
 from typing import Optional
 
-def venv_lookup(project_dir: str) -> Optional[str]:  # pylint: disable=unused-argument
+import toml
+
+from alfred import manifest, logger
+from alfred.exceptions import AlfredException
+from alfred.venv_plugins.base import venv_is_valid
+
+
+def venv_lookup(project_dir: str) -> Optional[str]:
+    ignore = manifest.lookup_parameter_project('venv_poetry_ignore', project_dir)
+    if ignore is True:
+        return None
+
+    _is_poetry_project = is_poetry_project(project_dir)
+    if _is_poetry_project:
+        poetry = shutil.which('poetry')
+        if poetry is None:
+            logger.warning('Poetry manages this project. Poetry is missing from your system.: https://python-poetry.org/docs/#installation')
+            return None
+
+        result = subprocess.run([poetry, 'env', 'info', '--path'], cwd=project_dir, capture_output=True, check=False)
+        if result.returncode != 0:
+            logger.warning('Poetry virtual environment is missing. You should run poetry install.')
+            logger.warning(result.stdout)
+            logger.warning(result.stderr)
+            return None
+
+        venv = result.stdout.decode('utf-8').strip()
+        if venv_is_valid(venv):
+            return venv
+        else:
+            logger.warning(f"Poetry virtual environment {venv} is not valid")
+    else:
+        logger.debug(f"{project_dir} is not recognize as a poetry project")
+
     return None
+
+
+def is_poetry_project(project_dir: str) -> bool:
+    """
+    Check if the project is a poetry project.
+
+    :param project_dir: project directory
+    :return:
+    """
+
+    _is_poetry_project = False
+    pyproject_path = os.path.join(project_dir, 'pyproject.toml')
+    if os.path.isfile(pyproject_path) is False:
+        return False
+
+    with io.open(pyproject_path, 'r', encoding='utf-8') as pyproject_filep:
+        try:
+            pyproject_dict = toml.load(pyproject_filep)
+            build_system = pyproject_dict.get('build-system', {})
+            build_backend = build_system.get('build-backend', None)
+            if build_backend == 'poetry.core.masonry.api':
+                _is_poetry_project = True
+        except BaseException as exception:
+            raise AlfredException(f'fail to parse {pyproject_path}') from exception
+
+    return _is_poetry_project

--- a/src/alfred/venv_plugins/poetry.py
+++ b/src/alfred/venv_plugins/poetry.py
@@ -1,0 +1,9 @@
+"""
+Detect when a project use poetry. He retrieve the virtual environment it created.
+
+If the parameter venv_poetry_ignore is set in the section project, then the code move on to the next plugin.
+"""
+from typing import Optional
+
+def venv_lookup(project_dir: str) -> Optional[str]:  # pylint: disable=unused-argument
+    return None

--- a/src/alfred/venv_plugins/poetry.py
+++ b/src/alfred/venv_plugins/poetry.py
@@ -31,8 +31,6 @@ def venv_lookup(project_dir: str) -> Optional[str]:
         result = subprocess.run([poetry, 'env', 'info', '--path'], cwd=project_dir, capture_output=True, check=False)
         if result.returncode != 0:
             logger.warning('Poetry virtual environment is missing. You should run poetry install.')
-            logger.warning(result.stdout)
-            logger.warning(result.stderr)
             return None
 
         venv = result.stdout.decode('utf-8').strip()

--- a/src/alfred/venv_plugins/venv.py
+++ b/src/alfred/venv_plugins/venv.py
@@ -1,0 +1,21 @@
+"""
+Retrieves the virtual environment that is declared in the project manifest.
+
+If the parameter venv is absent from the section project, then the code move on to the next plugin.
+"""
+from typing import Optional
+
+from alfred import manifest, logger
+from alfred.venv_plugins.base import venv_is_valid
+
+
+def venv_lookup(project_dir: str) -> Optional[str]:
+    venv = manifest.lookup_parameter_project('venv', project_dir)
+    if venv is None:
+        return None
+
+    if venv_is_valid(venv):
+        return venv
+
+    logger.warning(f"venv {venv} declared in project manifest is not valid, you shoud install / reinstall it")
+    return None

--- a/tests/fixtures/project_with_poetry/.alfred.toml
+++ b/tests/fixtures/project_with_poetry/.alfred.toml
@@ -1,0 +1,6 @@
+[alfred]
+
+[alfred.project]
+command = [
+    'customdir/*.py'
+]

--- a/tests/fixtures/project_with_poetry/.hooks/hook_started.py
+++ b/tests/fixtures/project_with_poetry/.hooks/hook_started.py
@@ -1,0 +1,6 @@
+import os
+import shutil
+import subprocess
+
+poetry_path = shutil.which('poetry')
+subprocess.run([poetry_path, 'install'], cwd=os.getcwd(), stdout=None, stderr=None)

--- a/tests/fixtures/project_with_poetry/pyproject.toml
+++ b/tests/fixtures/project_with_poetry/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "project-with-poetry"
+version = "0.1.0"
+description = ""
+authors = []
+readme = "README.md"
+packages = [{include = "project_with_poetry"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/project_with_poetry/pyproject.toml
+++ b/tests/fixtures/project_with_poetry/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "project_with_poetry"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 
 
 [build-system]

--- a/tests/integrations/venv_plugins/test_poetry.py
+++ b/tests/integrations/venv_plugins/test_poetry.py
@@ -4,6 +4,7 @@ import sys
 import fixtup
 import pytest
 
+from alfred.logger import logger
 from alfred.venv_plugins import poetry
 
 
@@ -12,9 +13,6 @@ def test_venv_should_detect_poetry_environment():
         """
         As poetry is already used by alfred, the poetry info that is renamed points to the project folder.
         """
-        if sys.version_info < (3, 8):
-            pytest.skip('poetry requires python 3.8+')
-
         venv = poetry.venv_lookup(os.getcwd())
 
         assert venv is not None, f"venv {venv} should be detected"

--- a/tests/integrations/venv_plugins/test_poetry.py
+++ b/tests/integrations/venv_plugins/test_poetry.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import fixtup
+import pytest
+
+from alfred.venv_plugins import poetry
+
+
+def test_venv_should_detect_poetry_environment():
+    with fixtup.up('project_with_poetry'):
+        """
+        As poetry is already used by alfred, the poetry info that is renamed points to the project folder.
+        """
+        if sys.version_info < (3, 8):
+            pytest.skip('poetry requires python 3.8+')
+
+        venv = poetry.venv_lookup(os.getcwd())
+
+        assert venv is not None, f"venv {venv} should be detected"


### PR DESCRIPTION
* ignore this workflow when ``venv_poetry_ignore`` is set
* detect the presence of poetry inside the ``pyproject.toml``
* detect the presence of poetry executable
* display warning if poetry is in ``pyproject.toml`` and poetry executable is missing

```textplain
Poetry manages this project. Poetry is missing from your system.
https://python-poetry.org/docs/#installation
```

* detect the venv using poetry