### PR TITLE
run virtual environment in pseudo terminal instead of subprocess on command invocation

### DIFF
--- a/src/alfred/cli.py
+++ b/src/alfred/cli.py
@@ -114,13 +114,18 @@ class AlfredCli(click.MultiCommand):
             cmd_output = self.resolve_command(ctx, args)
 
             if cmd_output is not None and alfred_ctx.should_use_external_venv():
-                alfred_ctx.invoke_through_external_venv(args)
-                return
-
-        """
-        The command is executed by click normally.
-        """
-        super().invoke(ctx)
+                pty_support = False if alfred_ctx.test_runner_used() else True  # pylint: disable=simplifiable-if-expression
+                alfred_ctx.invoke_through_external_venv(args, pty=pty_support)
+            else:
+                """
+                The command is executed by click normally.
+                """
+                super().invoke(ctx)
+        else:
+            """
+            The command is executed by click normally.
+            """
+            super().invoke(ctx)
 
     def parse_args(self, ctx: Context, args: List[str]) -> List[str]:
         if alfred_ctx.cli_args() is None:

--- a/src/alfred/main.py
+++ b/src/alfred/main.py
@@ -185,7 +185,7 @@ def sh(command: Union[str, List[str]], fail_message: str = None) -> process.Comm
     return process.sh(command, fail_message)
 
 
-def run(command: Union[str, process.Command], args: Optional[List[str]] = None, exit_on_error=True) -> Tuple[int, str, str]:
+def run(command: Union[str, process.Command], args: Optional[Union[str, List[str]]] = None, exit_on_error=True) -> Tuple[int, str, str]:
     """
     Most of the process run by alfred are supposed to stop
     if the excecution process is finishing with an exit code of 0
@@ -220,6 +220,9 @@ def run(command: Union[str, process.Command], args: Optional[List[str]] = None, 
     :param command: command or text program to execute
     :param exit_on_error: break the flow if the exit code is different of 0 (active by default)
     """
+    if isinstance(args, str):
+        args = [args]
+
     result = process.run(command, args)
     if result.return_code != 0 and exit_on_error:
         raise Exit(result.return_code)

--- a/tests/acceptances/test_cli.py
+++ b/tests/acceptances/test_cli.py
@@ -356,7 +356,7 @@ def test_alfred_execution_directory_return_the_directory_where_invocation_is_don
 
 
 def test_alfred_working_directory_is_the_root_of_the_subproject():
-    with fixtup.up('multiproject'):
+    with fixtup.up('multiproject'), alfred_fixture.use_new_context():
         directory_to_create = os.path.join('products', 'product1', 'src')
         os.makedirs(directory_to_create, exist_ok=True)
 

--- a/tests/fixtures/alfred_fixture.py
+++ b/tests/fixtures/alfred_fixture.py
@@ -103,4 +103,5 @@ def use_new_context():
     sets up a new independent execution context for a test
     """
     with ctx.use_new_context():
+        ctx.test_runner_use(True)
         yield


### PR DESCRIPTION
implement #59, fix #33

A developer can launch a command which depends on a virtual environment other than the one he has activated in his terminal.  In this case, alfred switch the virtual environment by itself but lost interactivity in the operation. Color and rich prompt are note supported anymore. 

During this call, there is no need to capture standard output and error output. By ignoring the standard and error outputs, we can recover interactivity.

```bash
alfred tests
```

For commands invoked in a command, we keep the current mode to make the standard output and error output accessible at the end of the command.

```python
@alfred.command('ci', help="execute continuous integration process of alfred")
@alfred.option('-v', '--verbose', is_flag=True)
def ci(verbose: bool):
    alfred.invoke_command('alfred_check')
    if alfred.is_posix():
        alfred.invoke_command('lint', verbose=verbose)
    else:
        print("linter is not supported on non posix platform as windows")

    alfred.invoke_command('tests', verbose=verbose)
```